### PR TITLE
CI workflow to create releases automatically from tags

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,0 @@
-[target.x86_64-apple-darwin]
-linker = "x86_64-apple-darwin14-clang"
-ar = "x86_64-apple-darwin14-ar"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           sudo apt install ${{ matrix.linker-package }}
           mkdir -p .cargo
           echo [targret.${{ matrix.target }}] > .cargo/config
-          echo linker '"'${{ matrix.linker }}'"' >> /cargo/config
+          echo linker '"'${{ matrix.linker }}'"' >> cargo/config
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,22 @@ jobs:
           echo [target.${{ matrix.target }}] > .cargo/config.toml
           echo linker = '"'${{ matrix.linker }}'"' >> .cargo/config.toml
 
-      - name: Install cross-compiling toolchain
+      - name: Install stable rust toolchain (not cross)
+        if: "!matrix.cross"
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          override: true
+
+      - name: Install stable rust toolchain (cross)
         if: matrix.cross
-        run: rustup target add ${{ matrix.target }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          override: true
+          target: ${{ matrix.target }}
 
       - name: Build
         if: "!matrix.cross"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           sudo apt install ${{ matrix.linker-package }}
           mkdir -p .cargo
           echo [targret.${{ matrix.target }}] > .cargo/config
-          echo linker '"'${{ matrix.linker }}'"' >> .cargo/config
+          echo linker = '"'${{ matrix.linker }}'"' >> .cargo/config
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
 
       - name: Rename executable (windows)
         run: Rename-Item .\target\release\cppm.exe cppm-windows-amd64.exe
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
         with:
           files: target/release/cppm*64?(.exe)
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,34 +49,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: false # for testing only, remove when finished
       matrix:
         include:
-          - name: linux-aarch64
-            os: ubuntu-latest
-            linker-package: gcc-aarch64-linux-gnu
-            linker: aarch64-linux-gnu-gcc
-            target: aarch64-unknown-linux-gnu
-
           - name: macos-aarch64
             os: macos-latest
             target: aarch64-apple-darwin
 
-          # - name: windows-aarch64
-          #   os: windows-latest
-          #   target: aarch64-pc-windows-msvc
-
     steps:
       - uses: actions/checkout@v3
-
-      - name: Install linker (linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt update
-          sudo apt install ${{ matrix.linker-package }}
-          mkdir -p .cargo
-          echo [targret.${{ matrix.target }}] > .cargo/config
-          echo linker = '"'${{ matrix.linker }}'"' >> .cargo/config
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -85,21 +65,11 @@ jobs:
           default: true
           override: true
 
-      - name: Build (linux)
-        run: cargo build --release --bins --target ${{ matrix.target }}
-        env:
-          CC: ${{ matrix.linker }}
-
-      - name: Build (other)
+      - name: Build
         run: cargo build --release --bins --target ${{ matrix.target }}
 
-      - name: Rename executable (*nix)
-        if: matrix.os != 'windows-latest'
+      - name: Rename executable
         run: mv target/${{ matrix.target }}/release/cppm target/${{ matrix.target }}/release/cppm-${{ matrix.name }}
-
-      # - name: Rename executable (windows)
-      #   if: matrix.os == 'windows-latest'
-      #   run: Rename-Item .\target\${{ matrix.target }}\release\cppm.exe cppm-${{ matrix.name }}.exe
 
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,98 +10,85 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: false
       matrix:
-        include:
-          - build: linux-amd64
-            os: ubuntu-latest
-            cross: false
-
-          - build: macos-amd64
-            os: macos-latest
-            cross: false
-
-          - build: windows-amd64
-            os: windows-latest
-            cross: false
-
-          - build: linux-aarch64
-            os: ubuntu-latest
-            cross: true
-            linker-package: gcc-aarch64-linux-gnu
-            linker: aarch64-linux-gnu-gcc
-            target: aarch64-unknown-linux-gnu
-
-          - build: macos-aarch64
-            os: macos-latest
-            cross: true
-            target: aarch64-apple-darwin
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3
 
-      # - name: Extract version from tag
-      #   id: version
-      #   uses: damienaicheh/extract-version-from-tag-action@v1.0.0
-
-      - name: Install cross compiler
-        if: matrix.os == 'ubuntu-latest' && matrix.cross
-        run: |
-          sudo apt update
-          sudo apt install ${{ matrix.linker-package }}
-          mkdir -p .cargo
-          echo [target.${{ matrix.target }}] > .cargo/config.toml
-          echo linker = '"'${{ matrix.linker }}'"' >> .cargo/config.toml
-
-      - name: Install stable rust toolchain (not cross)
-        if: "!matrix.cross"
-        uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           default: true
           override: true
-
-      - name: Install stable rust toolchain (cross)
-        if: matrix.cross
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
-          target: ${{ matrix.target }}
 
       - name: Build
-        if: "!matrix.cross"
-        run: cargo build --release
+        run: cargo build --release --bins
 
-      - name: Build (linux cross)
-        if: matrix.os == 'ubuntu-latest' && matrix.cross
-        run: cargo build --release --target ${{ matrix.target }}
-        env:
-          CC: ${{ matrix.linker }}
+      - name: Rename executable (linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: mv target/release/cppm target/release/cppm-linux-amd64
 
-      - name: Build (mac cross)
-        if: matrix.os == 'macos-latest' && matrix.cross
-        run: cargo build --release --target ${{ matrix.target }}
+      - name: Rename executable (mac)
+        if: matrix.os == 'macos-latest'
+        run: mv target/release/cppm target/release/cppm-macos-amd64
 
-      - name: Archive executable
-        if: matrix.os != 'windows-latest' && !matrix.cross
-        working-directory: ./target/release
-        run: tar czvf ../../../cppm-${{ matrix.build }}.tar.gz cppm
-
-      - name: Archive executable (cross)
-        if: matrix.os != 'windows-latest' && matrix.cross
-        working-directory: ./target/${{ matrix.target }}/release
-        run: tar czvf ../../../cppm-${{ matrix.build }}.tar.gz cppm
-
-      - name: Archive executable (windows)
+      - name: Rename executable (windows)
         if: matrix.os == 'windows-latest'
-        working-directory: ./target/release
-        run: Compress-Archive -LiteralPath cppm.exe -DestinationPath ../../cppm-windows-amd64.zip
+        run: Rename-Item .\target\release\cppm.exe cppm-windows-amd64.exe
 
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
-          files: cppm-*
+          files: target/release/cppm*64?(.exe)
           draft: true
-          # prerelease: ${{ env.PRE_RELEASE != '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-aarch64:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false # for testing only, remove when finished
+      matrix:
+        include:
+          - name: linux-aarch64
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+
+          - name: macos-aarch64
+            os: macos-latest
+            target: aarch64-apple-darwin
+
+          - name: windows-aarch64
+            os: windows-latest
+            target: aarch64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          default: true
+          override: true
+
+      - name: Build
+        run: cargo build --release --bins --target ${{ matrix.target }}
+
+      - name: Rename executable (*nix)
+        if: matrix.os != 'windows-latest'
+        run: mv target/${{ matrix.target }}/release/cppm target/${{ matrix.target }}/release/cppm-${{ matrix.name }}
+
+      - name: Rename executable (windows)
+        if: matrix.os == 'windows-latest'
+        run: Rename-Item .\target\${{ matrix.target }}\release\cppm.exe cppm-${{ matrix.name }}.exe
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: target/${{ matrix.target }}/release/cppm*64?(.exe)
+          draft: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         run: mv target/release/cppm target/release/cppm-macos-amd64
 
       - name: Rename executable (windows)
+        if: matrix.os == 'windows-latest'
         run: Rename-Item .\target\release\cppm.exe cppm-windows-amd64.exe
 
       - name: Create release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Extract version from tag
+        id: version
+        uses: damienaicheh/extract-version-from-tag-action@v1.0.0
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -42,6 +46,7 @@ jobs:
         with:
           files: target/release/cppm*64?(.exe)
           draft: true
+          prerelease: ${{ env.PRE_RELEASE != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -57,6 +62,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Extract version from tag
+        id: version
+        uses: damienaicheh/extract-version-from-tag-action@v1.0.0
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -76,5 +85,6 @@ jobs:
         with:
           files: target/${{ matrix.target }}/release/cppm*64?(.exe)
           draft: true
+          prerelease: ${{ env.PRE_RELEASE != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release-amd64:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        include:
+          - build: linux-amd64
+            os: ubuntu-latest
+            cross: false
+
+          - build: macos-amd64
+            os: macos-latest
+            cross: false
+
+          - build: windows-amd64
+            os: windows-latest
+            cross: false
+
+          - build: linux-aarch64
+            os: ubuntu-latest
+            cross: true
+            linker-package: gcc-aarch64-linux-gnu
+            linker: aarch64-linux-gnu-gcc
+            target: aarch64-unknown-linux-gnu
+
+          - build: macos-aarch64
+            os: macos-latest
+            cross: true
+            target: aarch64-apple-darwin
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Extract version from tag
+        id: version
+        uses: damienaicheh/extract-version-from-tag-action@v1.0.0
+
+      - name: Install cross compiler
+        if: matrix.os == 'ubuntu-latest' && matrix.cross
+        run: |
+          sudo apt update
+          sudo apt install ${{ matrix.linker-package }}
+          mkdir -p .cargo
+          echo [target.${{ matrix.target }}] > .cargo/config.toml
+          echo linker = '"'${{ matrix.linker }}'"' >> .cargo/config.toml
+
+      - name: Install cross-compiling toolchain
+        if: matrix.cross
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build
+        if: "!matrix.cross"
+        run: cargo build --release
+
+      - name: Build (linux cross)
+        if: matrix.os == 'ubuntu-latest' && matrix.cross
+        run: cargo build --release --target ${{ matrix.target }}
+        env:
+          CC: ${{ matrix.linker }}
+
+      - name: Build (mac cross)
+        if: matrix.os == 'macos-latest' && matrix.cross
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Archive executable
+        if: matrix.os != 'windows-latest' && !matrix.cross
+        working-directory: ./target/release
+        run: tar czvf ../../../cppm-${{ matrix.build }}.tar.gz cppm
+
+      - name: Archive executable (cross)
+        if: matrix.os != 'windows-latest' && matrix.cross
+        working-directory: ./target/${{ matrix.target }}/release
+        run: tar czvf ../../../cppm-${{ matrix.build }}.tar.gz cppm
+
+      - name: Archive executable (windows)
+        if: matrix.os == 'windows-latest'
+        working-directory: ./target/release
+        run: Compress-Archive -LiteralPath cppm.exe -DestinationPath ../../cppm-windows-amd64.zip
+        
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: cppm-*
+          draft: true
+          prerelease: ${{ env.PRE_RELEASE != '' }}
+        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,16 +85,21 @@ jobs:
           default: true
           override: true
 
-      - name: Build
+      - name: Build (linux)
+        run: cargo build --release --bins --target ${{ matrix.target }}
+        env:
+          CC: ${{ matrix.linker }}
+
+      - name: Build (other)
         run: cargo build --release --bins --target ${{ matrix.target }}
 
       - name: Rename executable (*nix)
         if: matrix.os != 'windows-latest'
         run: mv target/${{ matrix.target }}/release/cppm target/${{ matrix.target }}/release/cppm-${{ matrix.name }}
 
-      - name: Rename executable (windows)
-        if: matrix.os == 'windows-latest'
-        run: Rename-Item .\target\${{ matrix.target }}\release\cppm.exe cppm-${{ matrix.name }}.exe
+      # - name: Rename executable (windows)
+      #   if: matrix.os == 'windows-latest'
+      #   run: Rename-Item .\target\${{ matrix.target }}\release\cppm.exe cppm-${{ matrix.name }}.exe
 
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
 
 jobs:
   release-amd64:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Extract version from tag
-        id: version
-        uses: damienaicheh/extract-version-from-tag-action@v1.0.0
+      # - name: Extract version from tag
+      #   id: version
+      #   uses: damienaicheh/extract-version-from-tag-action@v1.0.0
 
       - name: Install cross compiler
         if: matrix.os == 'ubuntu-latest' && matrix.cross
@@ -84,11 +84,10 @@ jobs:
         if: matrix.os == 'windows-latest'
         working-directory: ./target/release
         run: Compress-Archive -LiteralPath cppm.exe -DestinationPath ../../cppm-windows-amd64.zip
-        
+
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
           files: cppm-*
           draft: true
-          prerelease: ${{ env.PRE_RELEASE != '' }}
-        
+          # prerelease: ${{ env.PRE_RELEASE != '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: mv target/release/cppm target/release/cppm-macos-amd64
 
-      - name: Rename executable (windows)true
+      - name: Rename executable (windows)
+        run: Rename-Item .\target\release\cppm.exe cppm-windows-amd64.exe
         with:
           files: target/release/cppm*64?(.exe)
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - build: linux-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
 
 jobs:
   release-amd64:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           sudo apt install ${{ matrix.linker-package }}
           mkdir -p .cargo
           echo [targret.${{ matrix.target }}] > .cargo/config
-          echo linker '"'${{ matrix.linker }}'"' >> cargo/config
+          echo linker '"'${{ matrix.linker }}'"' >> .cargo/config
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install linker (linux)
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt update
           sudo apt install ${{ matrix.linker-package }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: mv target/release/cppm target/release/cppm-macos-amd64
 
-      - name: Rename executable (windows)
-        if: matrix.os == 'windows-latest'
-        run: Rename-Item .\target\release\cppm.exe cppm-windows-amd64.exe
-
-      - name: Create release
-        uses: softprops/action-gh-release@v1
+      - name: Rename executable (windows)true
         with:
           files: target/release/cppm*64?(.exe)
           draft: true
@@ -54,18 +49,28 @@ jobs:
         include:
           - name: linux-aarch64
             os: ubuntu-latest
+            linker-package: gcc-aarch64-linux-gnu
+            linker: aarch64-linux-gnu-gcc
             target: aarch64-unknown-linux-gnu
 
           - name: macos-aarch64
             os: macos-latest
             target: aarch64-apple-darwin
 
-          - name: windows-aarch64
-            os: windows-latest
-            target: aarch64-pc-windows-msvc
+          # - name: windows-aarch64
+          #   os: windows-latest
+          #   target: aarch64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install linker (linux)
+        run: |
+          sudo apt update
+          sudo apt install ${{ matrix.linker-package }}
+          mkdir -p .cargo
+          echo [targret.${{ matrix.target }}] > .cargo/config
+          echo linker '"'${{ matrix.linker }}'"' >> /cargo/config
 
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
When a tag beginning with `v` is pushed, the workflow will automatically build and create a release with binaries available for Windows, macOS, and Linux amd64, and macOS aarch64.